### PR TITLE
Get-TargetResource: Fix Get-TargetResource logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## Unreleased
 
 * Initial public release of SChannelDsc
+* Get-TargetResource: Fixed Get-TargetResource logic

--- a/Modules/SChannelDsc/DSCResources/MSFT_Protocol/MSFT_Protocol.psm1
+++ b/Modules/SChannelDsc/DSCResources/MSFT_Protocol/MSFT_Protocol.psm1
@@ -43,9 +43,9 @@ function Get-TargetResource
     $serverDisabledByDefaultResult = Get-SChannelItem -ItemKey $serverItemKey `
                                                       -ItemValue 'DisabledByDefault'
 
-    $serverResult = $null
-    if ($serverEnabledResult -eq $serverDisabledByDefaultResult)
-    {
+    if(($serverEnabledResult -eq 'Enabled' -and $serverDisabledByDefaultResult -eq 'Disabled') -or
+       ($serverEnabledResult -eq 'Disabled' -and $serverDisabledByDefaultResult -eq 'Enabled' ) -or
+       ($serverEnabledResult -eq 'Default' -and $serverDisabledByDefaultResult -eq 'Default' ))  {
         $serverResult = $serverEnabledResult
     }
 
@@ -53,10 +53,9 @@ function Get-TargetResource
     $clientEnabledResult = Get-SChannelItem -ItemKey $clientItemKey
     $clientDisabledByDefaultResult = Get-SChannelItem -ItemKey $clientItemKey `
                                                       -ItemValue 'DisabledByDefault'
-
-    $clientResult = $null
-    if ($clientEnabledResult -eq $clientDisabledByDefaultResult)
-    {
+    if(($clientEnabledResult -eq 'Enabled' -and $clientDisabledByDefaultResult -eq 'Disabled') -or
+       ($clientEnabledResult -eq 'Disabled' -and $clientDisabledByDefaultResult -eq 'Enabled' ) -or
+       ($clientEnabledResult -eq 'Default' -and $clientDisabledByDefaultResult -eq 'Default' )) {
         $clientResult = $clientEnabledResult
     }
 

--- a/Tests/Unit/SChannelDsc/SChannel.Protocol.Tests.ps1
+++ b/Tests/Unit/SChannelDsc/SChannel.Protocol.Tests.ps1
@@ -127,7 +127,7 @@ Describe -Name $Global:SCDscHelper.DescribeHeader -Fixture {
         Context -Name "When the protocol isn't enabled and should be" -Fixture {
             $testParams = @{
                 Protocol = "TLS 1.0"
-                State    = "Disabled"
+                State    = "Enabled"
             }
 
             Mock -CommandName Get-SChannelItem -MockWith {
@@ -145,7 +145,7 @@ Describe -Name $Global:SCDscHelper.DescribeHeader -Fixture {
             }
 
             It "Should return false from the Test method" {
-                Test-TargetResource @testParams | Should Be $true
+                Test-TargetResource @testParams | Should Be $false
             }
 
             It "Should disable the protocol in the set method" {
@@ -157,7 +157,7 @@ Describe -Name $Global:SCDscHelper.DescribeHeader -Fixture {
         Context -Name "When the protocol isn't enabled and shouldn't be" -Fixture {
             $testParams = @{
                 Protocol = "TLS 1.0"
-                State    = "Enabled"
+                State    = "Disabled"
             }
 
             Mock -CommandName Get-SChannelItem -MockWith {
@@ -173,7 +173,7 @@ Describe -Name $Global:SCDscHelper.DescribeHeader -Fixture {
             }
 
             It "Should return true from the Test method" {
-                Test-TargetResource @testParams | Should Be $false
+                Test-TargetResource @testParams | Should Be $true
             }
         }
     }

--- a/Tests/Unit/SChannelDsc/SChannel.Protocol.Tests.ps1
+++ b/Tests/Unit/SChannelDsc/SChannel.Protocol.Tests.ps1
@@ -28,6 +28,10 @@ Describe -Name $Global:SCDscHelper.DescribeHeader -Fixture {
                 return 'Enabled'
             }
 
+            Mock -CommandName Get-SChannelItem -ParameterFilter { $ItemValue -eq 'DisabledByDefault' }  -MockWith {
+                return 'Disabled'
+            }
+
             It "Should return present from the Get method" {
                 (Get-TargetResource @testParams).State | Should Be "Enabled"
             }
@@ -45,6 +49,10 @@ Describe -Name $Global:SCDscHelper.DescribeHeader -Fixture {
 
             Mock -CommandName Get-SChannelItem -MockWith {
                 return 'Enabled'
+            }
+
+            Mock -CommandName Get-SChannelItem -ParameterFilter { $ItemValue -eq 'DisabledByDefault' }  -MockWith {
+                return 'Disabled'
             }
 
             Mock -CommandName Set-SChannelItem -MockWith { }
@@ -73,6 +81,10 @@ Describe -Name $Global:SCDscHelper.DescribeHeader -Fixture {
                 return 'Default'
             }
 
+            Mock -CommandName Get-SChannelItem -ParameterFilter { $ItemValue -eq 'DisabledByDefault' }  -MockWith {
+                return 'Default'
+            }
+
             It "Should return Enabled from the Get method" {
                 (Get-TargetResource @testParams).State | Should Be "Default"
             }
@@ -90,6 +102,10 @@ Describe -Name $Global:SCDscHelper.DescribeHeader -Fixture {
 
             Mock -CommandName Get-SChannelItem -MockWith {
                 return 'Disabled'
+            }
+
+            Mock -CommandName Get-SChannelItem -ParameterFilter { $ItemValue -eq 'DisabledByDefault' }  -MockWith {
+                return 'Enabled'
             }
 
             Mock -CommandName Set-SChannelItem -MockWith { }
@@ -111,11 +127,15 @@ Describe -Name $Global:SCDscHelper.DescribeHeader -Fixture {
         Context -Name "When the protocol isn't enabled and should be" -Fixture {
             $testParams = @{
                 Protocol = "TLS 1.0"
-                State    = "Enabled"
+                State    = "Disabled"
             }
 
             Mock -CommandName Get-SChannelItem -MockWith {
                 return 'Disabled'
+            }
+
+            Mock -CommandName Get-SChannelItem -ParameterFilter { $ItemValue -eq 'DisabledByDefault' }  -MockWith {
+                return 'Enabled'
             }
 
             Mock -CommandName Set-SChannelItem -MockWith { }
@@ -125,7 +145,7 @@ Describe -Name $Global:SCDscHelper.DescribeHeader -Fixture {
             }
 
             It "Should return false from the Test method" {
-                Test-TargetResource @testParams | Should Be $false
+                Test-TargetResource @testParams | Should Be $true
             }
 
             It "Should disable the protocol in the set method" {
@@ -137,19 +157,23 @@ Describe -Name $Global:SCDscHelper.DescribeHeader -Fixture {
         Context -Name "When the protocol isn't enabled and shouldn't be" -Fixture {
             $testParams = @{
                 Protocol = "TLS 1.0"
-                State    = "Disabled"
+                State    = "Enabled"
             }
 
             Mock -CommandName Get-SChannelItem -MockWith {
                 return 'Disabled'
             }
 
-            It "Should return absent from the Get method" {
+            Mock -CommandName Get-SChannelItem -ParameterFilter { $ItemValue -eq 'DisabledByDefault' }  -MockWith {
+                return 'Enabled'
+            }
+
+            It "Should disabled from the Get method" {
                 (Get-TargetResource @testParams).State | Should Be "Disabled"
             }
 
             It "Should return true from the Test method" {
-                Test-TargetResource @testParams | Should Be $true
+                Test-TargetResource @testParams | Should Be $false
             }
         }
     }


### PR DESCRIPTION
#### Pull Request (PR) description
As stated in #6 the logic for getting $serverResult will result in $null. Since comparison of serverEnabled and serverDisabledByDefault result will only be equal if no key are set. 

Verifying 3 scenario's 
1. Enabled (Enabled = 1 , DisabledByDefault = 0)
1. Disabled (Enabled = 0 , DisabledByDefault = 1)
1. Default   (Enabled = null , DisabledByDefault = null)

Included an additional Mock for DisabledByDefault since the result is relevant. 

#### This Pull Request (PR) fixes the following issues
    - Fixes #6

#### Task list
- [ ] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md in the resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/schanneldsc/7)
<!-- Reviewable:end -->
